### PR TITLE
fixed regexp to properly handle urls with hashes

### DIFF
--- a/Cutegram/emojis.cpp
+++ b/Cutegram/emojis.cpp
@@ -207,7 +207,7 @@ QString Emojis::textToEmojiText(const QString &txt, int size, bool skipLinks, bo
         pos += atag.size();
     }
 
-    QRegExp tags_rxp("\\#(\\w+)");
+    QRegExp tags_rxp("\\s\\#(\\w+)");
     pos = 0;
     while (!skipLinks && (pos = tags_rxp.indexIn(res, pos)) != -1)
     {


### PR DESCRIPTION
If you're try to open link like `http://url/path#anchor`, cutegram will change it to `http://url/path<a href='tag://anchor'>/#anchor`.
I fixed it by adding \s to regexp, so now such links open correctly.