### PR TITLE
Fix default sideBarWidth in AccountHome.qml

### DIFF
--- a/account/AccountHome.qml
+++ b/account/AccountHome.qml
@@ -31,7 +31,7 @@ ToolKit.AccountPageItem {
     Sidebar.Sidebar {
         id: sidebar
         height: parent.height
-        width: CutegramSettings.sideBarWidth
+        width: CutegramSettings.sideBarWidth * Devices.density
         z: 10
         onLoadMessageRequest: messagesFrame.loadFrom(message)
         onCurrentPeerChanged: {


### PR DESCRIPTION
default sideBarWidth didn't consider device density