### PR TITLE
Binaries will be installed if BinaryMode is enabled.

### DIFF
--- a/cutegram.pro
+++ b/cutegram.pro
@@ -2,6 +2,8 @@ contains(CONFIG, binaryMode) {
     CONFIG += c++11
     TARGET = cutegram
     QT += qml quick gui widgets core
+    target.path = $$PREFIX/bin
+    INSTALLS += target
     TEMPLATE = app
     SOURCES += main.cpp
     RESOURCES += \


### PR DESCRIPTION
Fix issue #231. Binaries will be installed if BinaryMode is enabled.