### PR TITLE
Add init step to libqtelegram instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ First, you should build and install libqtelegram.
 And:
 
     cd libqtelegram-aseman-edition
+    ./init
     mkdir build && cd build
     qmake -r CONFIG+=typeobjects  ..
     


### PR DESCRIPTION
Instructions in libqtelegram-aseman-edition have an `./init` script execution listed, which is not found here.  Running the other steps without that results in an error.